### PR TITLE
feat: readability improvements to OSV record

### DIFF
--- a/policies/V8-policy.json
+++ b/policies/V8-policy.json
@@ -8,6 +8,6 @@
     "main"
   ],
   "freshness_days": 7,
-  "policy_link": "https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md",
-  "description": "Dependency on outdated V8 found. Please update to the latest [beta](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/beta), [stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/stable), or [extended stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/extended) versions."
+  "summary": "Outdated dependency on V8 found (see details)",
+  "description": "Outdated dependency on V8 found (see [policy](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md).\n\nPlease update to the latest [beta](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/beta), [stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/stable), or [extended stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/extended) versions."
 }

--- a/policies/V8-policy.json
+++ b/policies/V8-policy.json
@@ -8,6 +8,7 @@
     "main"
   ],
   "freshness_days": 7,
+  "policy_link": "https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md",
   "summary": "Outdated dependency on V8 found (see details)",
   "description": "Outdated dependency on V8 found (see [policy](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md).\n\nPlease update to the latest [beta](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/beta), [stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/stable), or [extended stable](https://chromium.googlesource.com/v8/v8.git/+/refs/heads/extended) versions."
 }

--- a/src/main.go
+++ b/src/main.go
@@ -29,7 +29,7 @@ type Policy struct {
 	ID            string   `json:"id"`
 	Repository    string   `json:"repository"`
 	FreshnessDays int      `json:"freshness_days"`
-	PolicyLink    string   `json:"policy_link"`
+	Summary       string   `json:summary`
 	Description   string   `json:"description"`
 	Branches      []string `json:"branches"`
 }
@@ -222,7 +222,7 @@ func updateAdvisory(advisory *Advisory, policy *Policy, cache map[string][]strin
 
 	advisory.ID = policy.ID
 	advisory.Modified = nowTimestamp
-	advisory.Summary = policy.PolicyLink
+	advisory.Summary = policy.Summary
 	advisory.Details = policy.Description
 	advisory.Affected = []AffectedItem{*affectedItem}
 

--- a/src/main.go
+++ b/src/main.go
@@ -29,6 +29,7 @@ type Policy struct {
 	ID            string   `json:"id"`
 	Repository    string   `json:"repository"`
 	FreshnessDays int      `json:"freshness_days"`
+	PolicyLink    string   `json:"policy_link"`
 	Summary       string   `json:summary`
 	Description   string   `json:"description"`
 	Branches      []string `json:"branches"`

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -237,7 +237,7 @@ func TestUpdateAdvisory(t *testing.T) {
 		ID:            "policyID",
 		Repository:    "owner/repo",
 		FreshnessDays: 1,
-		PolicyLink:    "policyLink",
+		Summary:       "policySummary",
 		Description:   "policyDescription",
 	}
 
@@ -261,7 +261,7 @@ func TestUpdateAdvisory(t *testing.T) {
 		ID:            "policyID",
 		Modified:      nowTimestamp,
 		Published:     nowTimestamp,
-		Summary:       "policyLink",
+		Summary:       "policySummary",
 		Details:       "policyDescription",
 		Affected: []AffectedItem{
 			{


### PR DESCRIPTION
This improves the generation of the OSV record:

- the summary is human readable
- the policy link is included in the details
- the details are split over multiple lines

So that the record views more nicely at OSV.dev
and output from the likes of OSV-Scanner
(which may only include the summary) is more
user-friendly.

Per https://ossf.github.io/osv-schema/#summary-details-fields
- the summary is plain text
- details is CommonMark markdown