### PR TITLE
ci: miscellaneous improvements to update_advisory

### DIFF
--- a/.github/workflows/update_advisory.yml
+++ b/.github/workflows/update_advisory.yml
@@ -18,24 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version: '1.21'
+        go-version: '1.24.1'
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Run tests
-      run: go test ./src/... -v
+      run: go test -v ./src/...
       continue-on-error: false
     - name: Run Go application
       run: |
-        go build -o update-advisory src/main.go
-        ./update-advisory
-        rm update-advisory
+        go run src/main.go
 
     - name: Commit changes
       run: |
         git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"2
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add ./advisories/V8-advisory.json
         git add ./src/V8-cache.json
         git commit -m "Update advisories/V8_advisory.json and src/V8-cache.json"


### PR DESCRIPTION
This

  - follows [recommended best practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and pins the actions used by their commit hash (and updates to the latest available versions)
  - uses the latest available version of the Go compiler
  - streamlines the execution of the Go binary by simply using `go run`
  - removes an errant character from the configured git `user.email` string