### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6
       with:
         go-version: '1.21'
 

--- a/.github/workflows/update_advisory.yml
+++ b/.github/workflows/update_advisory.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
       with:
         go-version: '1.24.1'
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Run tests
       run: go test -v ./src/...
       continue-on-error: false


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`11bd719`](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683), [`v3`](https://github.com/actions/checkout/releases/tag/v3) | [`de0fac2`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) | [Release](https://github.com/actions/checkout/releases/tag/v6) | run_tests.yml, update_advisory.yml |
| `actions/setup-go` | [`0aaccfd`](https://github.com/actions/setup-go/commit/0aaccfd150d50ccaeb58ebd88d36e91967a5f35b), [`v3`](https://github.com/actions/setup-go/releases/tag/v3) | [`7a3fe6c`](https://github.com/actions/setup-go/commit/7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5) | [Release](https://github.com/actions/setup-go/releases/tag/v6) | run_tests.yml, update_advisory.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/setup-go** (v5.4.0 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-go/releases) for breaking changes
- **actions/checkout** (v4.2.2 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
